### PR TITLE
Allow illegally structured ARB annotations in i18next resource

### DIFF
--- a/helpers-json/i18next.js
+++ b/helpers-json/i18next.js
@@ -1,7 +1,7 @@
 // i18next v4 json format defined at https://www.i18next.com/misc/json-format
 const flat = require('flat');
 const { regex } = require('@l10nmonster/helpers');
-const { flattenAndSplitResources, ARB_ANNOTATION_MARKER } = require('./utils');
+const { flattenAndSplitResources, ARB_ANNOTATION_MARKER, FLATTEN_SEPARATOR } = require('./utils');
 
 const isArbAnnotations = e => e[0].split('.').slice(-2)[0].startsWith(ARB_ANNOTATION_MARKER);
 const validArbAnnotations = new Set(['description', 'type', 'context', 'placeholders', 'screenshot', 'video', 'source_text']);
@@ -34,6 +34,12 @@ function parseResourceAnnotations(resource, enableArbAnnotations) {
             parsedNotes[key] = notes.join("\n")
         } else {
             parsedNotes[key] = arbAnnotations
+            // If ARB annotation is not an object, treat it as if it is a resource too
+            // so that a linter implementation may catch it and warn developers about it
+            const keys = key.split(FLATTEN_SEPARATOR)
+            const fix = keys.pop()
+            const fixedKey = keys.concat(`${ARB_ANNOTATION_MARKER}${fix}`).join(FLATTEN_SEPARATOR)
+            res[fixedKey] = arbAnnotations
         }
     }
     return [ Object.entries(res), parsedNotes ];

--- a/tests/filters/json.test.js
+++ b/tests/filters/json.test.js
@@ -686,6 +686,41 @@ describe("placeholders tests", () => {
         };
         const output = await resourceFilter.parseResource({ resource: JSON.stringify(resource) });
         expect(output).toMatchObject(expectedOutput);
+    })
+})
 
+describe("Parse illegally structured ARB", () => {
+    global.l10nmonster = {
+        logger: {
+            verbose: console.log
+        }
+    }
+    test("parses root ARB key that is illegally structured", async () => {
+        // value for the "@key" should have an object,
+        // but it should not crash even if it doesn't either
+        const resource = {
+            key: "value",
+            "@key": "comment",
+            ns: {
+                key: "value",
+                "@key": "comment",
+                child: {
+                    key: "value",
+                    "@key": "comment",
+                }
+            }
+        }
+        const expectedOutput = {
+            segments: [
+                { sid: "key", str: "value" },
+                { sid: "ns.key", str: "value" },
+                { sid: "ns.child.key", str: "value" },
+                { sid: "@key", str: "comment" },
+                { sid: "ns.@key", str: "comment" },
+                { sid: "ns.child.@key", str: "comment" },
+            ]
+        }
+        const output = await resourceFilter.parseResource({ resource: JSON.stringify(resource) });
+        expect(output).toMatchObject(expectedOutput);
     })
 })


### PR DESCRIPTION
In order to make the linter to see and warn the illegally structured ARB metadata for IEP-540, the filter needs to return those keys that look like an ARB metadata as if it was another string.

As you can see if you run the new unit test with the current implementation, the current implementation fails so our linter cannot see those strings in the parsed resource, thus cannot warn developers about illegally structured ARB.

The PR fixes it by editing the filter predicate function and the regular expression so that they remain in the parsed resources as if they are string resources.