### PR TITLE
Implements pluggable arb annotation handlers

### DIFF
--- a/helpers-json/package.json
+++ b/helpers-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@l10nmonster/helpers-json",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Helpers to deal with JSON file formats",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
helpers-json/I18nextFilter accepts the new parameter `arbAnnotationHandlers` whose value is an object of

```
{
  <name of ARB annotation>: (name, data) => <function that returns a string or undefined>,
  ...
}
```

The intention is so we can replace the current `placeholders` handler that simply does `JSON.stringify` with something that replaces them with `PH(...)`.